### PR TITLE
Refactor prefetchQueries for blogs

### DIFF
--- a/libs/prefetchQueries/blog.ts
+++ b/libs/prefetchQueries/blog.ts
@@ -9,9 +9,10 @@ import {
 } from '@/services/blogServices';
 
 export const prefetchBlogs = async (queryClient: QueryClient) =>
-  await queryClient.prefetchQuery({
+  await queryClient.prefetchInfiniteQuery({
     queryKey: [BlogQueryEnum.BLOGS],
-    queryFn: () => fetchBlogs(1)
+    queryFn: async ({ pageParam }) => await fetchBlogs(pageParam),
+    initialPageParam: 1
   });
 
 export const prefetchCurrentUserBlogs = async (queryClient: QueryClient) =>


### PR DESCRIPTION
This pull request updates the prefetchQueries for blogs. Instead of using `queryClient.prefetchQuery`, it now uses `queryClient.prefetchInfiniteQuery` to fetch blogs. The `queryFn` now includes a parameter `pageParam` and the initial value is set to 1.