### PR TITLE
Fix blogs layout and change redirect in at pathname '/'

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,7 +8,6 @@ export default async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
   const isAuthPage = pathname.startsWith('/auth');
-  const isMainPage = pathname === '/';
 
   if (isAuthPage) {
     if (isAuth) {
@@ -17,9 +16,6 @@ export default async function middleware(req: NextRequest) {
   } else {
     if (!isAuth) {
       return NextResponse.redirect(new URL('/auth', req.url));
-    }
-    if (isMainPage && isAuth) {
-      return NextResponse.redirect(new URL('/dashboard', req.url));
     }
   }
 

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,31 +1,40 @@
-import { Image, Container, Title, Text, Button, SimpleGrid } from '@mantine/core';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
+
+import { Button, Container, Image, SimpleGrid, Text, Title } from '@mantine/core';
 
 export default function NotFound() {
   const router = useRouter();
   return (
-    <Container className='flex-center h-dvh'>
-      <SimpleGrid spacing={{ base: 40, sm: 80 }} cols={{ base: 1, sm: 2 }}>
-        <Image src='/images/404.svg' className='md:hidden' alt='404' />
-        <div>
-          <Title className='mb-[var(--mantine-spacing-md)] text-4xl font-black max-sm:text-3xl'>
-            Something is not right...
-          </Title>
-          <Text c='dimmed' size='lg'>
-            Page you are trying to open does not exist. You may have mistyped the address, or the page has
-            been moved to another URL. If you think this is an error contact support.
-          </Text>
-          <Button
-            variant='outline'
-            size='md'
-            mt='xl'
-            className='max-sm:w-full'
-            onClick={() => router.push('/')}>
-            Get back to home page
-          </Button>
-        </div>
-        <Image src='/images/404.svg' className='max-md:hidden' alt='404' />
-      </SimpleGrid>
-    </Container>
+    <>
+      <Head>
+        <title>NotFound | Synergy</title>
+        <meta name='description' content='NotFound' />
+      </Head>
+
+      <Container className='flex-center h-dvh'>
+        <SimpleGrid spacing={{ base: 40, sm: 80 }} cols={{ base: 1, sm: 2 }}>
+          <Image src='/images/404.svg' className='md:hidden' alt='404' />
+          <div>
+            <Title className='mb-[var(--mantine-spacing-md)] text-4xl font-black max-sm:text-3xl'>
+              Something is not right...
+            </Title>
+            <Text c='dimmed' size='lg'>
+              Page you are trying to open does not exist. You may have mistyped the address, or the page has
+              been moved to another URL. If you think this is an error contact support.
+            </Text>
+            <Button
+              variant='outline'
+              size='md'
+              mt='xl'
+              className='max-sm:w-full'
+              onClick={() => router.push('/')}>
+              Get back to home page
+            </Button>
+          </div>
+          <Image src='/images/404.svg' className='max-md:hidden' alt='404' />
+        </SimpleGrid>
+      </Container>
+    </>
   );
 }

--- a/pages/blogs/[id]/index.tsx
+++ b/pages/blogs/[id]/index.tsx
@@ -32,9 +32,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   return {
     props: {
-      dehydratedState: dehydrate(queryClient),
-      notFound: isExist.status === 'rejected'
-    }
+      dehydratedState: dehydrate(queryClient)
+    },
+    notFound: isExist.status === 'rejected'
   };
 };
 

--- a/pages/blogs/index.tsx
+++ b/pages/blogs/index.tsx
@@ -77,4 +77,8 @@ const Blogs = () => {
   );
 };
 
+Blogs.getLayout = function getLayout(page: React.ReactElement) {
+  return <DefaultLayout>{page}</DefaultLayout>;
+};
+
 export default Blogs;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,6 +18,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {
       dehydratedState: dehydrate(queryClient)
+    },
+    redirect: {
+      destination: '/dashboard',
+      permanent: true
     }
   };
 };


### PR DESCRIPTION
This PR fixes the layout of the blogs page and changes the redirect behavior when accessing the pathname '/'. The previous redirect behavior was incorrect and has been updated to redirect to the '/dashboard' page permanently.